### PR TITLE
:sparkles: add support for pinning version of peer/opts dependencies

### DIFF
--- a/modules/node_modules/@knit/knit-core/index.js
+++ b/modules/node_modules/@knit/knit-core/index.js
@@ -182,26 +182,47 @@ exports.getDependencyVersion = (dep, modules, updated, nextVersion) => {
   };
 };
 
-exports.getPeerDependencyVersion = (dep, modules, updated, nextVersion) => {
-  if (needle.pkg.dependencies && needle.pkg.dependencies[dep]) {
-    return needle.pkg.dependencies[dep];
-  } else if (updated.includes(dep)) {
-    return nextVersion;
-  } else if (modules.includes(dep)) {
-    const pkg = exports.readPkg(dep);
-    if (pkg && pkg.version) {
-      return pkg.version;
-    }
+exports.getPeerDependencyVersion = (pkg, dep, modules, updated, nextVersion) => {
+  const version = (pkg.peerDependencies && pkg.peerDependencies[dep])
+    ? pkg.peerDependencies[dep]
+    // $FlowIgnore
+    : needle.pkg.peerDependencies[dep];
+
+  if (version === '*') {
+    const v = (needle.pkg.devDependencies && needle.pkg.devDependencies[dep])
+      ? needle.pkg.devDependencies[dep]
+      : exports.getDependencyVersion(dep, modules, updated, nextVersion);
+
+    return parseInt(v.replace(/^[^\d]/, ''), 10).toString();
   }
 
-  throw {
-    message: `Missing dependency: ${dep}`,
-    stderr: `Could not find ${dep} in the project package.json. Try \`yarn add ${dep}\`.`,
-  };
+  return version;
+};
+
+exports.getOptionalDependencyVersion = (pkg, dep, modules, updated, nextVersion) => {
+  const version = (pkg.optionalDependencies && pkg.optionalDependencies[dep])
+    ? pkg.optionalDependencies[dep]
+    // $FlowIgnore
+    : needle.pkg.optionalDependencies[dep];
+
+  if (version === '*') {
+    const v = exports.getDependencyVersion(dep, modules, updated, nextVersion);
+
+    return parseInt(v.replace(/^[^\d]/, ''), 10).toString();
+  }
+
+  return version;
 };
 
 exports.updateModulePkg = (pkg, modules, used, updated, version) => {
   const projectPkg = needle.pkg;
+  const deps = used.concat(Object.keys(pkg.dependencies || {}));
+  const peers = Object.keys(pkg.peerDependencies || {}).concat(
+    Object.keys(projectPkg.peerDependencies || {})
+  );
+  const opts = Object.keys(pkg.optionalDependencies || {}).concat(
+    Object.keys(projectPkg.optionalDependencies || {})
+  );
   const nextVersion = version || projectPkg.version;
 
   return (
@@ -223,18 +244,19 @@ exports.updateModulePkg = (pkg, modules, used, updated, version) => {
         main: path.join(needle.paths.distStub, needle.paths.libStub, 'index.js'),
         // fall back to project package if no version given in workflow
         version: nextVersion,
-        dependencies: used.concat(Object.keys(pkg.dependencies || {})).filter(d => (
-          !Object.keys(projectPkg.peerDependencies || {}).includes(d)
-        )).reduce((acc, d) => (
+        dependencies: deps.filter(d => !peers.includes(d)).reduce((acc, d) => (
           Object.assign(acc, {
             [d]: exports.getDependencyVersion(d, modules, updated, nextVersion),
           })
         ), {}),
-        peerDependencies: used.filter(d => (
-          Object.keys(projectPkg.peerDependencies || {}).includes(d)
-        )).reduce((acc, d) => (
+        peerDependencies: peers.reduce((acc, d) => (
           Object.assign(acc, {
-            [d]: parseInt(exports.getPeerDependencyVersion(d, modules, updated, nextVersion).replace(/^[^\d]/, ''), 10).toString(),
+            [d]: exports.getPeerDependencyVersion(pkg, d, modules, updated, nextVersion),
+          })
+        ), {}),
+        optionalDependencies: opts.reduce((acc, d) => (
+          Object.assign(acc, {
+            [d]: exports.getOptionalDependencyVersion(pkg, d, modules, updated, nextVersion),
           })
         ), {}),
       }

--- a/modules/node_modules/@knit/knit/package.json
+++ b/modules/node_modules/@knit/knit/package.json
@@ -5,7 +5,7 @@
   "bin": {
     "knit": "dist/lib/bin/cli.js"
   },
-  "dependencies": {
+  "peerDependencies": {
     "babel-cli": "*"
   }
 }

--- a/modules/node_modules/@knit/needle/index.js.flow
+++ b/modules/node_modules/@knit/needle/index.js.flow
@@ -45,8 +45,9 @@ export type TPkgJson = {
   tags?: Array<string>,
   keywords?: Array<string>,
   dependencies?: TPkgJsonDeps,
-  peerDependencies?: TPkgJsonDeps,
   devDependencies?: TPkgJsonDeps,
+  peerDependencies?: TPkgJsonDeps,
+  optionalDependencies?: TPkgJsonDeps,
   jest?: Object,
   eslintConfig?: Object,
   knit?: {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,8 @@
     "testEnvironment": "node"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "babel-cli": "*"
-  },
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-rc.4",
-    "babel-cli": "6.18.0",
     "babel-eslint": "7.1.0",
     "babel-loader": "6.2.7",
     "babel-plugin-transform-class-properties": "^6.19.0",
@@ -90,6 +86,7 @@
     "flow": "flow check || exit 0"
   },
   "devDependencies": {
+    "babel-cli": "6.18.0",
     "babel-jest": "17.0.0",
     "eslint": "3.10.2",
     "flow-bin": "0.36.0",


### PR DESCRIPTION
use "*" to have knit figure out the version or set the version manually in root or module package.json

Closes #5
Closes #18