### PR TITLE
:sparkles: add module/unpkg and remove browser from build

### DIFF
--- a/modules/node_modules/@knit/knit-core/__tests__/unit.test.js
+++ b/modules/node_modules/@knit/knit-core/__tests__/unit.test.js
@@ -570,18 +570,20 @@ describe('updateModulePkgBrowser', () => {
     expect(umpb({ name: 'name' }, PATHS)).toEqual({
       name: 'name',
       'jsnext:main': path.join('jsnext', 'index.js'),
-      browser: path.join('umd', 'index.min.js'),
+      module: path.join('jsnext', 'index.js'),
+      unpkg: path.join('umd', 'index.min.js'),
     });
   });
   it('overwrites existsing values for those fields', () => {
     expect(umpb({
       name: 'name',
       'jsnext:main': 'foo',
-      browser: 'bar',
+      unpkg: 'bar',
     }, PATHS)).toEqual({
       name: 'name',
       'jsnext:main': path.join('jsnext', 'index.js'),
-      browser: path.join('umd', 'index.min.js'),
+      module: path.join('jsnext', 'index.js'),
+      unpkg: path.join('umd', 'index.min.js'),
     });
   });
 });

--- a/modules/node_modules/@knit/knit-core/index.js
+++ b/modules/node_modules/@knit/knit-core/index.js
@@ -280,6 +280,7 @@ export const updateModulePkgBrowser: TUpdateModulePkgBrowser = (pkg, paths) => (
   ...pkg,
   ...{
     'jsnext:main': pathJoin(paths.jsnext, 'index.js'),
-    browser: pathJoin(paths.umd, 'index.min.js'),
+    module: pathJoin(paths.jsnext, 'index.js'),
+    unpkg: pathJoin(paths.umd, 'index.min.js'),
   },
 });


### PR DESCRIPTION
renamed target fields in built `package.json`s to better fit webpack defaults

Closes #32