### PR TITLE
:fix: babel-polyfill for regeneratorRuntime

### DIFF
--- a/modules/node_modules/@knit/knit-core/index.js
+++ b/modules/node_modules/@knit/knit-core/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import 'babel-polyfill';
 import type { TPkgJson, TPkgJsonDeps, TPaths } from '@knit/needle';
 
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-plugin-transform-react-jsx-self": "6.11.0",
     "babel-plugin-transform-react-jsx-source": "6.9.0",
+    "babel-polyfill": "^6.20.0",
     "babel-preset-env": "^1.1.1",
     "babel-preset-react": "6.16.0",
     "babel-relay-plugin": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,6 +742,14 @@ babel-polyfill@^6.16.0, babel-polyfill@^6.6.1:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
 
+babel-polyfill@^6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.20.0.tgz#de4a371006139e20990aac0be367d398331204e7"
+  dependencies:
+    babel-runtime "^6.20.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-env@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.1.1.tgz#f7df25886d0f7299a3dd56b408696aeea79c79e9"


### PR DESCRIPTION
to fix:

```
$ knit server
/Users/awilmer/Projects/portal-ui-relay/node_modules/@knit/knit-core/dist/lib/index.js:138
  var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee(modules, paths) {
                               ^

ReferenceError: regeneratorRuntime is not defined
    at /Users/awilmer/Projects/portal-ui-relay/node_modules/@knit/knit-core/dist/lib/index.js:138:32
    at Object.<anonymous> (/Users/awilmer/Projects/portal-ui-relay/node_modules/@knit/knit-core/dist/lib/index.js:168:2)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/awilmer/Projects/portal-ui-relay/node_modules/@knit/knit/dist/lib/bin/cli-list.js:9:12)
error Command failed with exit code 1.
```