### PR TITLE
:sparkles: adds --scope, --ignore and --force to cli

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,8 @@
     "no-throw-literal": 0,
     "no-param-reassign": 0,
     "no-unused-expressions": 0,
-    "max-len": 0
+    "max-len": 0,
+
+    "no-multi-assign": 0
   }
 }

--- a/modules/node_modules/@knit/common-tasks/__tests__/tasks.test.js
+++ b/modules/node_modules/@knit/common-tasks/__tests__/tasks.test.js
@@ -8,6 +8,7 @@ const Listr = require('listr');
 
 
 const modules = require('../tasks/modules');
+const updated = require('../tasks/updated');
 const packages = require('../tasks/packages');
 
 jest.mock('@knit/needle', () => {
@@ -28,10 +29,20 @@ describe('modules', () => {
     expect(ctx.modules).toEqual(['@scope/module-b', 'module-a']);
     expect(ctx.updated).toBeFalsy();
   });
-  it('also adds all modules to ctx.updated when --force-all passed', async () => {
-    const ctx = await new Listr(modules, { renderer: SilentRenderer }).run({ forceAll: true });
-    expect(ctx.modules).toEqual(['@scope/module-b', 'module-a']);
-    expect(ctx.updated).toEqual(['@scope/module-b', 'module-a']);
+});
+
+describe('updated', () => {
+  it('adds modules to ctx.updated when --force is passed', async () => {
+    const mods = ['@scope/module-b', 'module-a'];
+    const ctx = await new Listr(updated, { renderer: SilentRenderer }).run({ modules: mods, force: true });
+    expect(ctx.modules).toEqual(mods);
+    expect(ctx.updated).toEqual(mods);
+  });
+  it('adds limits scope of modules --force and --scope is passed', async () => {
+    const mods = ['@scope/module-b', 'module-a'];
+    const ctx = await new Listr(updated, { renderer: SilentRenderer }).run({ modules: mods, scope: ['a'], force: true });
+    expect(ctx.modules).toEqual(mods);
+    expect(ctx.updated).toEqual(['module-a']);
   });
 });
 

--- a/modules/node_modules/@knit/common-tasks/tasks/modules.js
+++ b/modules/node_modules/@knit/common-tasks/tasks/modules.js
@@ -7,7 +7,6 @@ const needle = require('@knit/needle');
 
 type TCtx = {
   modules: TModules,
-  updated: TModules,
 };
 
 const tasks = [
@@ -22,9 +21,6 @@ const tasks = [
         require('events').EventEmitter.defaultMaxListeners = modules.length; // eslint-disable-line
       }
       ctx.modules = modules;
-      if (ctx.forceAll) {
-        ctx.updated = modules;
-      }
     },
   },
 ];

--- a/modules/node_modules/@knit/common-tasks/tasks/updated.js
+++ b/modules/node_modules/@knit/common-tasks/tasks/updated.js
@@ -8,21 +8,24 @@ const knit = require('@knit/knit-core');
 const needle = require('@knit/needle');
 
 type TCtx = {
-  forceAll: boolean,
-  modules: TModules,
+  force: boolean,
+  scope: Array<string>,
+  ignore: Array<string>,
   tag: ?string,
+  modules: TModules,
   updated: TModules,
 };
 
 const tasks = [
   {
     title: 'getting last tag',
-    skip: (ctx: TCtx) => ctx.tag || ctx.forceAll,
+    skip: (ctx: TCtx) => ctx.tag || ctx.updated || ctx.force,
     task: (ctx: TCtx) => execa.stdout('git', ['describe', '--abbrev=0', '--tags']).then(tag => {
       ctx.tag = tag;
     }).catch(() => execa.stdout('git', ['rev-list', '--max-parents=0', 'HEAD']).then(commit => {
       ctx.tag = commit;
     })).catch(() => {
+      // no commit history
       ctx.tag = null;
     }),
   },
@@ -30,13 +33,26 @@ const tasks = [
     title: 'determining updated modules since last release',
     skip: (ctx: TCtx) => ctx.updated && `${ctx.updated.length} modules already found.`,
     task: (ctx: TCtx) => {
-      if (ctx.tag) {
+      if (ctx.tag && !ctx.force) {
         const modified = knit.findModifiedSince(ctx.modules, ctx.tag, needle.paths);
         return knit.findUpdatedModules(ctx.modules, modified, needle.paths).then(updated => {
           ctx.updated = updated;
+          if (ctx.scope) {
+            ctx.updated = ctx.updated.filter(module => ctx.scope.some(pattern => module.match(new RegExp(pattern))));
+          }
+          if (ctx.ignore) {
+            ctx.updated = ctx.updated.filter(module => !ctx.ignore.some(pattern => module.match(new RegExp(pattern))));
+          }
         });
       }
+
       ctx.updated = ctx.modules;
+      if (ctx.scope) {
+        ctx.updated = ctx.updated.filter(module => ctx.scope.some(pattern => module.match(new RegExp(pattern))));
+      }
+      if (ctx.ignore) {
+        ctx.updated = ctx.updated.filter(module => !ctx.ignore.some(pattern => module.match(new RegExp(pattern))));
+      }
 
       return ctx;
     },

--- a/modules/node_modules/@knit/knit/bin/cli-build.js
+++ b/modules/node_modules/@knit/knit/bin/cli-build.js
@@ -7,8 +7,10 @@ const log = require('@knit/logger');
 const tasks = require('@knit/common-tasks');
 
 type TArgv = {
-  forceAll: boolean,
-  skipPreflight: boolean,
+  scope: Array<string>,
+  ignore: Array<string>,
+  skip: boolean,
+  force: boolean,
 };
 
 module.exports = (argv: TArgv) => {
@@ -21,8 +23,5 @@ module.exports = (argv: TArgv) => {
   ], {
     renderer: log.getRenderer(argv),
     collapse: false,
-  }).run({
-    skipPreflight: argv.skipPreflight,
-    forceAll: argv.forceAll,
-  }).catch(errors.catchErrors);
+  }).run(argv).catch(errors.catchErrors);
 };

--- a/modules/node_modules/@knit/knit/bin/cli-list.js
+++ b/modules/node_modules/@knit/knit/bin/cli-list.js
@@ -13,29 +13,31 @@ const needle = require('@knit/needle');
 
 type TArgv = {
   modules: TModules,
+  scope: Array<string>,
+  ignore: Array<string>,
+  'show-dependencies': boolean,
+  'only-updated': boolean,
 };
 
 module.exports = (argv: TArgv) => {
   new Listr([
     ...tasks.modules,
     ...tasks.packages,
-    ...(argv.updated ? tasks.updated : []),
+    ...tasks.updated,
   ], {
     renderer: log.getRenderer(argv),
-  }).run().then(ctx => {
-    const publicModules = (ctx || {}).modules || [];
-    const modules = argv.modules.length // eslint-disable-line no-nested-ternary
-      ? argv.modules
-      : argv.updated
-        ? ctx.updated
-        : publicModules;
-    const fMs = modules.filter(m => publicModules.includes(m));
-    const nfMs = modules.filter(m => !publicModules.includes(m));
+  }).run({
+    scope: argv.scope,
+    ignore: argv.ignore,
+    force: !argv['only-updated'],
+  }).then(ctx => {
+    const publicModules = ctx.modules;
+    const modules = ctx.updated;
 
     console.log();
-    log.info(chalk.white(`showing dependencies for ${fMs.length}${argv.updated ? ' updated ' : ' '}modules`));
+    log.info(chalk.white(`showing dependencies for ${modules.length}${argv['only-updated'] ? ' updated ' : ' '}modules`));
     console.log();
-    Promise.all(fMs.map(m => knit.findDependencies(m, needle.paths).then(using => {
+    Promise.all(modules.map(m => knit.findDependencies(m, needle.paths).then(using => {
       const missing = knit.findMissingDependencies(using, publicModules, needle.pkg.dependencies);
 
       console.log(
@@ -47,7 +49,7 @@ module.exports = (argv: TArgv) => {
         ].join(''))
       );
 
-      if (argv.dependencies) {
+      if (argv['show-dependencies']) {
         if (using.length) {
           log.subtree(using.join(' '));
         }
@@ -57,12 +59,6 @@ module.exports = (argv: TArgv) => {
         }
         console.log();
       }
-    }).catch(errors.catchErrors))).then(() => {
-      if (nfMs.length) {
-        console.log();
-        log.warning(chalk.white('could not find the following modules'));
-        log.subtree(nfMs.join(' '));
-      }
-    });
+    }).catch(errors.catchErrors)));
   }).catch(errors.catchErrors);
 };

--- a/modules/node_modules/@knit/knit/bin/cli-publish.js
+++ b/modules/node_modules/@knit/knit/bin/cli-publish.js
@@ -18,8 +18,5 @@ module.exports = (argv) => {
   ], {
     renderer: log.getRenderer(argv),
     collapse: false,
-  }).run({
-    skipPreflight: argv.skipPreflight,
-    forceAll: argv.forceAll,
-  }).catch(errors.catchErrors);
+  }).run(argv).catch(errors.catchErrors);
 };

--- a/modules/node_modules/@knit/knit/bin/cli-release.js
+++ b/modules/node_modules/@knit/knit/bin/cli-release.js
@@ -23,9 +23,5 @@ module.exports = (argv) => {
   ], {
     renderer: log.getRenderer(argv),
     collapse: false,
-  }).run({
-    version: argv.version,
-    skipPreflight: argv.skipPreflight,
-    forceAll: argv.forceAll,
-  }).catch(errors.catchErrors);
+  }).run(argv).catch(errors.catchErrors);
 };

--- a/modules/node_modules/@knit/knit/bin/cli-stitch.js
+++ b/modules/node_modules/@knit/knit/bin/cli-stitch.js
@@ -16,8 +16,5 @@ module.exports = (argv) => {
   ], {
     renderer: log.getRenderer(argv),
     collapse: false,
-  }).run({
-    skipPreflight: argv.skipPreflight,
-    forceAll: argv.forceAll,
-  }).catch(errors.catchErrors);
+  }).run(argv).catch(errors.catchErrors);
 };

--- a/modules/node_modules/@knit/knit/bin/cli-validate.js
+++ b/modules/node_modules/@knit/knit/bin/cli-validate.js
@@ -13,7 +13,5 @@ module.exports = argv => {
     ...tasks.preflight.knit,
   ], {
     renderer: log.getRenderer(argv),
-  }).run({
-    skipPreflight: argv.skipPreflight,
-  }).catch(errors.catchErrors);
+  }).run(argv).catch(errors.catchErrors);
 };

--- a/modules/node_modules/@knit/knit/bin/cli-version.js
+++ b/modules/node_modules/@knit/knit/bin/cli-version.js
@@ -18,9 +18,5 @@ module.exports = (argv) => {
   ], {
     renderer: log.getRenderer(argv),
     collapse: false,
-  }).run({
-    version: argv.version,
-    skipPreflight: argv.skipPreflight,
-    forceAll: argv.forceAll,
-  }).catch(errors.catchErrors);
+  }).run(argv).catch(errors.catchErrors);
 };

--- a/modules/node_modules/@knit/knit/bin/cli.js
+++ b/modules/node_modules/@knit/knit/bin/cli.js
@@ -7,6 +7,27 @@ const readPkgUp = require('read-pkg-up');
 
 const pkg = readPkgUp.sync({ cwd: __dirname }).pkg;
 
+const options = {
+  scope: {
+    describe: 'Limit scope of command to modules matching regex',
+    type: 'array',
+  },
+  ignore: {
+    describe: 'Ignore modules matching regex',
+    type: 'array',
+  },
+  force: {
+    alias: 'f',
+    description: 'Run command on both up-to-date and updated modules',
+    type: 'boolean',
+  },
+  skip: {
+    alias: 's',
+    description: 'Skip preflight checks (not recommended)',
+    type: 'boolean',
+  },
+};
+
 require('yargs') // eslint-disable-line no-unused-expressions
   .version(pkg.version)
   .options({
@@ -21,17 +42,19 @@ require('yargs') // eslint-disable-line no-unused-expressions
       global: true,
     },
   })
-  .command('list [modules...]', 'List modules and their dependencies',
+  .command('list', 'List modules and their dependencies',
   (y) => (
     y
       .options({
-        d: {
-          alias: 'dependencies',
+        scope: options.scope,
+        ignore: options.ignore,
+        'show-dependencies': {
+          alias: 'd',
           describe: 'Show dependencies for each module',
           type: 'boolean',
         },
-        u: {
-          alias: 'updated',
+        'only-updated': {
+          alias: 'u',
           describe: 'Limit search to updated modules',
           type: 'boolean',
         },
@@ -42,18 +65,15 @@ require('yargs') // eslint-disable-line no-unused-expressions
     (y) => (
       y
         .options({
-          p: {
-            alias: 'port',
+          port: {
             description: 'Set server port',
             type: 'number',
           },
-          h: {
-            alias: 'host',
+          host: {
             description: 'Set server host',
             type: 'string',
           },
-          r: {
-            alias: 'proxy',
+          proxy: {
             description: 'Set proxy uri',
             type: 'string',
           },
@@ -61,67 +81,15 @@ require('yargs') // eslint-disable-line no-unused-expressions
     ), require('./cli-play'))
   .command('schema', 'Update graphql schema', yargs => yargs, require('./cli-relay'))
   .command('version <version>', 'Version updated modules',
-  (y) => (
-    y
-      .demand(1)
-      .options('f', {
-        alias: 'force-all',
-        description: 'Version all modules',
-      })
-      .options('s', {
-        alias: 'skip-preflight',
-        description: 'Skip preflight checks (not recommended)',
-      })
-  ), require('./cli-version'))
-  .command('build', 'Build updated modules',
-  (y) => (
-    y
-      .options('f', {
-        alias: 'force-all',
-        description: 'Build all modules.',
-      })
-      .options('s', {
-        alias: 'skip-preflight',
-        description: 'Skip preflight checks (not recommended)',
-      })
-  ), require('./cli-build'))
-  .command('stitch', 'Update the package.json of all modules with knitted dependencies and project meta data',
-  (y) => (
-    y
-      .options('f', {
-        alias: 'force-all',
-        description: 'Publish all modules',
-      })
-      .options('s', {
-        alias: 'skip-preflight',
-        description: 'Skip preflight checks (not recommended)',
-      })
-  ), require('./cli-stitch'))
-  .command('publish', 'Publish updated modules',
-  (y) => (
-    y
-      .options('f', {
-        alias: 'force-all',
-        description: 'Publish all modules',
-      })
-      .options('s', {
-        alias: 'skip-preflight',
-        description: 'Skip preflight checks (not recommended)',
-      })
-  ), require('./cli-publish'))
-  .command('release <version>', 'Run full release pipeline on updated modules.\nversion > build > knit > publish > push',
-  (y) => (
-    y
-      .demand(1)
-      .options('f', {
-        alias: 'force-all',
-        description: 'Release all modules',
-      })
-      .options('s', {
-        alias: 'skip-preflight',
-        description: 'Skip preflight checks (not recommended)',
-      })
-  ), require('./cli-release'))
+  (y) => y.demand(1).options(options), require('./cli-version'))
+  .command('build [modules...]', 'Build updated modules',
+  (y) => y.options(options), require('./cli-build'))
+  .command('stitch [modules...]', 'Update the package.json of all modules with knitted dependencies and project meta data',
+  (y) => y.options(options), require('./cli-stitch'))
+  .command('publish [modules...]', 'Publish updated modules',
+  (y) => y.options(options), require('./cli-publish'))
+  .command('release <version> [modules...]', 'Run full release pipeline on updated modules.\nversion > build > knit > publish > push',
+  (y) => y.demand(1).options(options), require('./cli-release'))
   .demand(1)
   .help()
   .argv;


### PR DESCRIPTION
- add --scope option to all commands that act on modules to limit scope of action
- add --ignore to filter out modules
- add --force option to include up-to-date modules as well as updated modules in command. Useful for republishing a package if there was an issue with a release without needing to update the code

ex.

```
babel-preset
babel-plugin (updated)
eslint-config

> knit publish --scope babel
babel-plugin

> knit publish --scope babel --force
babel-preset
bable-plugin

> knit publish --scope babel --ignore plugin --force
babel-preset
```