### PR TITLE
:sparkles: adds `run` and `exec` commands

### DIFF
--- a/modules/node_modules/@knit/knit/bin/cli-exec.js
+++ b/modules/node_modules/@knit/knit/bin/cli-exec.js
@@ -1,0 +1,22 @@
+/* @flow weak */
+
+const Listr = require('listr');
+
+const errors = require('@knit/nice-errors');
+const log = require('@knit/logger');
+const tasks = require('@knit/common-tasks');
+
+module.exports = (argv) => {
+  new Listr([
+    ...tasks.modules,
+    ...tasks.updated,
+    ...require('../tasks/exec'),
+  ], {
+    renderer: log.getRenderer(argv),
+    collapse: false,
+  }).run({
+    ...argv,
+    cmd: argv._.slice(1)[0],
+    args: argv._.slice(1).slice(1),
+  }).catch(errors.catchErrors);
+};

--- a/modules/node_modules/@knit/knit/bin/cli-run.js
+++ b/modules/node_modules/@knit/knit/bin/cli-run.js
@@ -1,0 +1,18 @@
+/* @flow weak */
+
+const Listr = require('listr');
+
+const errors = require('@knit/nice-errors');
+const log = require('@knit/logger');
+const tasks = require('@knit/common-tasks');
+
+module.exports = (argv) => {
+  new Listr([
+    ...tasks.modules,
+    ...tasks.updated,
+    ...require('../tasks/run'),
+  ], {
+    renderer: log.getRenderer(argv),
+    collapse: false,
+  }).run(argv).catch(errors.catchErrors);
+};

--- a/modules/node_modules/@knit/knit/bin/cli.js
+++ b/modules/node_modules/@knit/knit/bin/cli.js
@@ -60,25 +60,29 @@ require('yargs') // eslint-disable-line no-unused-expressions
         },
       })
   ), require('./cli-list'))
+  .command('run <script> [args...]', 'Run npm script on updated modules',
+  (y) => y.demand(1).options(options), require('./cli-run'))
+  .command('exec', 'Execute command on updated modules',
+  (y) => y.options(options), require('./cli-exec'))
   .command('validate', 'Validate modules for release', y => y, require('./cli-validate'))
   .command('server', 'Start a dev server',
-    (y) => (
-      y
-        .options({
-          port: {
-            description: 'Set server port',
-            type: 'number',
-          },
-          host: {
-            description: 'Set server host',
-            type: 'string',
-          },
-          proxy: {
-            description: 'Set proxy uri',
-            type: 'string',
-          },
-        })
-    ), require('./cli-play'))
+  (y) => (
+    y
+      .options({
+        port: {
+          description: 'Set server port',
+          type: 'number',
+        },
+        host: {
+          description: 'Set server host',
+          type: 'string',
+        },
+        proxy: {
+          description: 'Set proxy uri',
+          type: 'string',
+        },
+      })
+  ), require('./cli-play'))
   .command('schema', 'Update graphql schema', yargs => yargs, require('./cli-relay'))
   .command('version <version>', 'Version updated modules',
   (y) => y.demand(1).options(options), require('./cli-version'))

--- a/modules/node_modules/@knit/knit/tasks/exec.js
+++ b/modules/node_modules/@knit/knit/tasks/exec.js
@@ -1,0 +1,44 @@
+/* @flow */
+
+
+import type { TModules } from '@knit/knit-core';
+
+const Listr = require('listr');
+
+const knit = require('@knit/knit-core');
+const needle = require('@knit/needle');
+const execa = require('execa');
+
+type TCtx = {
+  modules: TModules,
+  updated: TModules,
+  script: string,
+  cmd: string,
+  args: Array<string>,
+};
+
+const tasks = [
+  {
+    title: 'exec',
+    task: (ctx: TCtx) => (
+      new Listr(ctx.updated.map(m => ({
+        title: m,
+        task: () => {
+          // using $KNIT_MODULE_NAME as an env gets auto-expanded before we can get ahold of it
+          // zsh eats it so you need to escape \$KNIT_MODULE_NAME
+          // but before we get access it gets eaten again so
+          // need to escape like \\\$KNIT_MODULE_NAME - which is too many \ to bother with
+          const args = ctx.args.map(x => (
+            x.replace('KNIT_MODULE_NAME', m)
+          ));
+
+          return execa(ctx.cmd, args, {
+            cwd: knit.pathJoin(needle.paths.modules, m),
+          });
+        },
+      })), { concurrent: false })
+    ),
+  },
+];
+
+module.exports = tasks;

--- a/modules/node_modules/@knit/knit/tasks/run.js
+++ b/modules/node_modules/@knit/knit/tasks/run.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+
+import type { TModules } from '@knit/knit-core';
+
+const Listr = require('listr');
+
+const knit = require('@knit/knit-core');
+const needle = require('@knit/needle');
+const yarn = require('@knit/yarn-utils');
+
+type TCtx = {
+  modules: TModules,
+  updated: TModules,
+  script: string,
+  args: Array<string>,
+};
+
+const tasks = [
+  {
+    title: 'npm run',
+    task: (ctx: TCtx) => (
+      new Listr(ctx.updated.map(m => ({
+        title: m,
+        skip: () => !(knit.readPkg(m, needle.paths).scripts || {})[ctx.script],
+        task: () => yarn.run(ctx.script, ctx.args, { cwd: knit.pathJoin(needle.paths.modules, m) }),
+      })), { concurrent: false })
+    ),
+  },
+];
+
+module.exports = tasks;

--- a/modules/node_modules/@knit/needle/index.js.flow
+++ b/modules/node_modules/@knit/needle/index.js.flow
@@ -48,6 +48,7 @@ export type TPkgJson = {
   devDependencies: TPkgJsonDeps,
   peerDependencies: TPkgJsonDeps,
   optionalDependencies: TPkgJsonDeps,
+  scripts?: {string: string},
   jest?: Object,
   eslintConfig?: Object,
   knit?: {

--- a/modules/node_modules/@knit/yarn-utils/index.js
+++ b/modules/node_modules/@knit/yarn-utils/index.js
@@ -50,9 +50,20 @@ export const publish: TPublish = opts => isInstalled()
   .then(() => yarnPublish(opts))
   .catch(() => npmPublish(opts));
 
+export type TRun = (script: string, args: Array<string>, opts: Object) => Promise<*>;
+export const yarnRun: TRun = (script, args, opts) => execa('yarn', ['run', script, ...args], opts);
+export const npmRun: TRun = (script, args, opts) => execa('npm', ['run', script, ...args], opts);
+export const run: TRun = (script, args, opts) => {
+  console.log(script, args, opts);
+  return isInstalled()
+  .then(() => yarnRun(script, args, opts))
+  .catch(() => npmRun(script, args, opts));
+};
+
 export default {
   isInstalled,
   init,
+  run,
   addDev,
   add,
   publishedVersion,


### PR DESCRIPTION
- `run` will run an npm script
- `exec` will run shell command
  - exec will replace KNIT_MODULE_NAME with the module name in the command
  - note that isn't $KNIT_MODULE_NAME because I was having trouble with zsh auto-evaluating it
  - needed to send it as `\\\$KNIT_MODULE_NAME` which seemed excessive

Closes #47