### PR TITLE
✨ add --label flag to exec cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "knit:clean": "rm -rf dist",
     "knit:copy": "npm run knit -- copy --ignore-path=@knit/**/{__mocks__,__tests__,*.js}",
     "knit:stitch": "npm run knit -- stitch --parallel --scope unpublished",
-    "knit:build:cjs": "NODE_ENV=production npm run knit -- exec --parallel --scope unpublished --include=@knit --exclude=jest -- babel . -d ROOT_DIR/dist/KNIT_MODULE_NAME --ignore __mocks__,__tests__,jest,create",
+    "knit:build:cjs": "NODE_ENV=production npm run knit -- exec --label 'Build CommonJS' --parallel --scope unpublished --include=@knit --exclude=jest -- babel . -d ROOT_DIR/dist/KNIT_MODULE_NAME --ignore __mocks__,__tests__,jest,create",
     "knit:build": "run-s knit:clean knit:copy knit:build:cjs knit:stitch",
     "knit:publish": "npm run knit -- exec --scope unpublished --working-dir dist -- npm publish --access public",
     "preversion": "run-s 'knit -- validate' lint flow test",

--- a/src/modules/@knit/knit/bin/cli.js
+++ b/src/modules/@knit/knit/bin/cli.js
@@ -75,7 +75,11 @@ require("yargs") // eslint-disable-line no-unused-expressions
     y =>
       y.options({
         ...options,
-        parallel
+        parallel,
+        label: {
+          describe: "Add a friendly label to exec output",
+          type: "string"
+        }
       }),
     require("./cli-exec")
   )
@@ -102,8 +106,8 @@ require("yargs") // eslint-disable-line no-unused-expressions
     require("./cli-copy")
   )
   .command(
-    "stitch [modules...]",
-    "Update the package.json of all modules with knitted dependencies and project meta data",
+    "stitch",
+    "Update the package.json of all packages with knitted dependencies and project meta data",
     y =>
       y.options({
         ...options,

--- a/src/modules/@knit/knit/tasks/exec.js
+++ b/src/modules/@knit/knit/tasks/exec.js
@@ -12,6 +12,7 @@ type TCtx = {
   modules: TModules,
   workingDir: ?string,
   cmd: string,
+  label: string,
   args: Array<string>,
   parallel: boolean
 };
@@ -20,27 +21,33 @@ const tasks = [
   {
     title: "exec",
     task: (ctx: TCtx) =>
-      new Listr(
-        ctx.modules.map(m => ({
-          title: m,
-          task: () => {
-            // using $KNIT_MODULE_NAME as an env gets auto-expanded before we can get ahold of it
-            // zsh eats it so you need to escape \$KNIT_MODULE_NAME
-            // but before we get access it gets eaten again so
-            // need to escape like \\\$KNIT_MODULE_NAME - which is too many \ to bother with
-            const args = ctx.args.map(x => {
-              x = x.replace("KNIT_MODULE_NAME", m);
-              x = x.replace("ROOT_DIR", needle.paths.rootDir);
-              return x;
-            });
+      new Listr([
+        {
+          title: `${ctx.label || ctx.cmd}`,
+          task: (ctx: TCtx) =>
+            new Listr(
+              ctx.modules.map(m => ({
+                title: m,
+                task: () => {
+                  // using $KNIT_MODULE_NAME as an env gets auto-expanded before we can get ahold of it
+                  // zsh eats it so you need to escape \$KNIT_MODULE_NAME
+                  // but before we get access it gets eaten again so
+                  // need to escape like \\\$KNIT_MODULE_NAME - which is too many \ to bother with
+                  const args = ctx.args.map(x => {
+                    x = x.replace("KNIT_MODULE_NAME", m);
+                    x = x.replace("ROOT_DIR", needle.paths.rootDir);
+                    return x;
+                  });
 
-            return execa(ctx.cmd, args, {
-              cwd: pathJoin(ctx.workingDir || needle.paths.modules, m)
-            });
-          }
-        })),
-        { concurrent: ctx.parallel }
-      )
+                  return execa(ctx.cmd, args, {
+                    cwd: pathJoin(ctx.workingDir || needle.paths.modules, m)
+                  });
+                }
+              })),
+              { concurrent: ctx.parallel }
+            )
+        }
+      ])
   }
 ];
 

--- a/src/modules/@knit/knit/tasks/stitch.js
+++ b/src/modules/@knit/knit/tasks/stitch.js
@@ -52,7 +52,7 @@ const createKnitTask = m => ({
 
 const tasks = [
   {
-    title: "stitching together updated modules",
+    title: "stitching together packages",
     task: (ctx: TCtx) =>
       new Listr(ctx.modules.map(createKnitTask), {
         concurrent: ctx.parallel


### PR DESCRIPTION
ex `knit exec --label 'Building CommonJS' -- babel`

Closes #69