### PR TITLE
🛠run validate in CI, windows needs cwd()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ notification:
   email: false
 script:
   - npm run lint -- --max-warnings=0 || travis_terminate 1
+  - npm run knit validate || travis_terminate 1
   - npm run flow || travis_terminate 1
   - npm run test || travis_terminate 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ test_script:
   - node --version
   - npm --version
   - npm run lint -- --max-warnings=0
+  - npm run knit validate
   - npm run flow
   - npm run test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2492,11 +2492,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "babylon": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-      "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "postversion": "run-s knit:build knit:publish"
   },
   "dependencies": {
-    "babylon": "7.0.0-beta.47",
     "chalk": "3.0.0-beta.1",
     "depcheck": "^0.8.3",
     "dotenv": "8.1.0",
@@ -53,6 +52,7 @@
     "pify": "4.0.1",
     "read-pkg": "5.2.0",
     "read-pkg-up": "7.0.0",
+    "require-package-name": "2.0.1",
     "semver": "5.7.1",
     "serialize-error": "^5.0.0",
     "update-notifier": "3.0.1",

--- a/src/packages/@knit/needle/index.js
+++ b/src/packages/@knit/needle/index.js
@@ -7,7 +7,7 @@ const pathJoin = require("@knit/path-join");
 
 const pkg = (readPkgUp.sync() || {}).packageJson || {};
 
-const ROOT_DIR = process.env.PWD || "";
+const ROOT_DIR = process.env.PWD || process.cwd() || "";
 const WORKING_DIR = pathJoin(process.env.KNIT_WORKING_DIR || "src/packages");
 const OUTPUT_DIR = pathJoin(process.env.KNIT_OUTPUT_DIR || "dist");
 

--- a/src/packages/@knit/nice-errors/index.js
+++ b/src/packages/@knit/nice-errors/index.js
@@ -2,7 +2,7 @@
 
 const chalk = require("chalk");
 const log = require("@knit/logger");
-const serializeError = require("serialize-error");
+const { serializeError } = require("serialize-error");
 
 exports.niceStackTrace = stack => {
   const stackLines = stack.split("\n");
@@ -31,6 +31,7 @@ exports.niceStackTrace = stack => {
 };
 
 exports.catchErrors = e => {
+  process.exitCode = 1;
   const err = serializeError(e);
   console.log();
   err.cmd && log.command(chalk.white(err.cmd));


### PR DESCRIPTION
Run validate in CI to catch missing/unused dependencies.

Interesting bug found where the `rootDir` was not being set in Windows. Tests did catch this because most packages do not care and if they do it gets mocked out. Running `validate` in CI made this apparent since depcheck actually needs an abs value. 