### PR TITLE
✨add support for commit ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "testEnvironment": "node"
   },
   "scripts": {
+    "pkgs": "npm run knit list -- --show-dependencies",
     "lint": "eslint --ext .js src",
     "lint:fix": "eslint --ext .js src --fix",
     "test": "jest",

--- a/src/packages/@knit/common-tasks/__tests__/tasks.test.js
+++ b/src/packages/@knit/common-tasks/__tests__/tasks.test.js
@@ -112,7 +112,7 @@ describe("filter", () => {
 describe("modified", () => {
   it("find modified packages and set them to ctx.modified and ctx.modules", async () => {
     const ctx = await new Listr(modified, { renderer: SilentRenderer }).run({
-      tag: "beep",
+      range: "beep",
       public: PUBLIC,
       modules: PUBLIC,
       modulesMap: MODULES

--- a/src/packages/@knit/common-tasks/tasks/preflight/istag.js
+++ b/src/packages/@knit/common-tasks/tasks/preflight/istag.js
@@ -10,11 +10,11 @@ const tasks = [
       execa("git", ["describe", "--abbrev=0", "--exact-match", "HEAD"])
         .then(() =>
           execa("git", ["describe", "--abbrev=0", "HEAD^"])
-            .then(previous => (ctx.tag = previous.stdout))
+            .then(previous => (ctx.range = previous.stdout))
             .catch(() =>
               execa("git", ["rev-list", "--max-parents=0", "HEAD^"]).then(
                 commit => {
-                  ctx.tag = commit.stdout;
+                  ctx.range = commit.stdout;
                 }
               )
             )

--- a/src/packages/@knit/find-modified-packages/index.js
+++ b/src/packages/@knit/find-modified-packages/index.js
@@ -53,20 +53,21 @@ export const findModifiedPackages: TFindModifiedPackages = (
 type TFindModifiedSince = (
   workspace: string,
   m: TPackages,
-  tag: string
+  range: string
 ) => TPackageNames;
 export const findModifiedSince: TFindModifiedSince = (
   workspace,
   modulesMap,
-  tag
+  range
 ) => {
   const output = execa.sync("git", [
     "diff",
-    "--dirstat=files,0",
-    tag,
+    "--name-only",
+    range,
     "--",
     workspace
   ]);
+
   const lines = (output.stdout || "").split("\n").filter(x => x.length);
 
   const modified = lines
@@ -76,7 +77,7 @@ export const findModifiedSince: TFindModifiedSince = (
     })
     .filter(Boolean)
     .reduce((acc, m) => (acc.includes(m) ? acc : acc.concat(m)), [])
-    .map(md => findKey(modulesMap, k => k === md) || "")
+    .map(md => findKey(modulesMap, k => k.dir === md) || "")
     .filter(m => Object.keys(modulesMap).includes(m));
 
   return modified;

--- a/src/packages/@knit/knit/bin/cli.js
+++ b/src/packages/@knit/knit/bin/cli.js
@@ -13,6 +13,11 @@ const options = {
     choices: ["public", "modified", "unpublished"],
     default: "public"
   },
+  range: {
+    describe:
+      "Used with `--scope modified` to pass commit range ex. HEAD~..HEAD",
+    type: "string"
+  },
   include: {
     describe: "Include only packages matching regex",
     type: "array"


### PR DESCRIPTION
add a --range flag that lets the user find modified files from a custom commit range

from last release tag:
--scope modified
from v1.0.0 tag:
--scope modified --range v1.0.0
from last commit:
--scope modified --range HEAD~..HEAD