### PR TITLE
✨auto release master, fetch latest pkg version from registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,8 @@ jobs:
           node-version: 10
           registry-url: https://registry.npmjs.org/
       - run: yarn install
-      # - name: Set to latest released version
-      #   run: npm version ${version-from-registry}
+      - name: Set to latest released version
+        run: yarn \#:version
       - name: Bump release version
         run: yarn \#:release
       - name: Build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.8.2",
+  "version": "0.0.0-monorepo",
   "license": "MIT",
   "repository": "knitjs/knit",
   "author": {
@@ -33,8 +33,9 @@
     "knit:stitch": "yarn knit stitch --parallel",
     "knit:build:cjs": "cross-env NODE_ENV=production babel src/packages -d dist --copy-files --extensions .js,.ts",
     "build": "run-s knit:clean knit:build:cjs knit:stitch",
-    "#:release": "babel-node src/packages/@knit/knit/bin/cli.js exec --scope modified --range HEAD~.. npm version patch --no-git-tag-version",
-    "#:prerelease": "babel-node src/packages/@knit/knit/bin/cli.js exec --scope modified --range HEAD~.. -- npm version 0.0.0-$(git rev-parse --short HEAD) --no-git-tag-version",
+    "#:version": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel --scope modified --range HEAD~.. npm version KNIT_MODULE_VERSION --no-git-tag-version",
+    "#:release": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel --scope modified --range HEAD~.. npm version patch --no-git-tag-version",
+    "#:prerelease": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel --scope modified --range HEAD~.. -- npm version 0.0.0-$(git rev-parse --short HEAD) --no-git-tag-version",
     "#:publish": "babel-node src/packages/@knit/knit/bin/cli.js exec --scope modified --range HEAD --working-dir dist -- npm publish"
   },
   "dependencies": {
@@ -43,6 +44,7 @@
     "dotenv": "8.1.0",
     "execa": "2.0.4",
     "fs-extra": "8.1.0",
+    "latest-version": "5.1.0",
     "listr": "^0.14.3",
     "listr-silent-renderer": "^1.1.1",
     "listr-update-renderer": "^0.5.0",

--- a/src/packages/@knit/common-tasks/package.json
+++ b/src/packages/@knit/common-tasks/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@knit/common-tasks",
   "description": "common cli tasks",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/depcheck/package.json
+++ b/src/packages/@knit/depcheck/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@knit/depcheck",
   "description": "Depcheck parsers for knit",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/find-dependencies/package.json
+++ b/src/packages/@knit/find-dependencies/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@knit/find-dependencies",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/find-modified-packages/package.json
+++ b/src/packages/@knit/find-modified-packages/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@knit/find-modified-packages",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/find-packages/package.json
+++ b/src/packages/@knit/find-packages/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@knit/find-packages",
   "description": "Find all packages in a folder",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/find-unpublished-packages/package.json
+++ b/src/packages/@knit/find-unpublished-packages/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@knit/find-unpublished-packages",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/get-package-name/package.json
+++ b/src/packages/@knit/get-package-name/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@knit/get-package-name",
-  "version": "0.6.1"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/is-scoped/package.json
+++ b/src/packages/@knit/is-scoped/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@knit/is-scoped",
-  "version": "0.6.1"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/knit-core/package.json
+++ b/src/packages/@knit/knit-core/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@knit/knit-core",
   "description": "Automated package resolution for monorepos",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/knit/package.json
+++ b/src/packages/@knit/knit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@knit/knit",
   "description": "Knit together packages using Yarn",
-  "version": "0.8.2",
+  "version": "0.0.0-monorepo",
   "bin": {
     "knit": "./bin/cli.js"
   }

--- a/src/packages/@knit/knit/tasks/exec.js
+++ b/src/packages/@knit/knit/tasks/exec.js
@@ -4,6 +4,7 @@ import type { TPackages } from "@knit/find-packages";
 import type { TPackageNames } from "@knit/knit-core";
 
 const Listr = require("listr");
+const latestVersion = require("latest-version");
 
 const needle = require("@knit/needle");
 const pathJoin = require("@knit/path-join");
@@ -30,19 +31,29 @@ const tasks = [
             new Listr(
               ctx.modules.map(m => ({
                 title: m,
-                task: () => {
+                task: async () => {
                   // using $KNIT_MODULE_NAME as an env gets auto-expanded before we can get ahold of it
                   // zsh eats it so you need to escape \$KNIT_MODULE_NAME
                   // but before we get access it gets eaten again so
                   // need to escape like \\\$KNIT_MODULE_NAME - which is too many \ to bother with
-                  const args = ctx.args.map(x => {
-                    x = x.replace("KNIT_MODULE_NAME", m);
-                    x = x.replace("KNIT_MODULE_DIR", ctx.modulesMap[m].dir);
-                    x = x.replace("ROOT_DIR", needle.paths.rootDir);
-                    return x;
-                  });
+                  const args = Promise.all(
+                    ctx.args.map(async x => {
+                      x = x.replace("KNIT_MODULE_NAME", m);
+                      x = x.replace("KNIT_MODULE_DIR", ctx.modulesMap[m].dir);
+                      x = x.replace("ROOT_DIR", needle.paths.rootDir);
 
-                  return execa(ctx.cmd, args, {
+                      if (x.includes("KNIT_MODULE_VERSION")) {
+                        x = x.replace(
+                          "KNIT_MODULE_VERSION",
+                          await latestVersion(m)
+                        );
+                      }
+
+                      return x;
+                    })
+                  );
+
+                  return execa(ctx.cmd, await args, {
                     cwd: pathJoin(ctx.modulesMap[m].path)
                   });
                 }

--- a/src/packages/@knit/logger/package.json
+++ b/src/packages/@knit/logger/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@knit/logger",
   "description": "cli logger",
-  "version": "0.7.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/needle/package.json
+++ b/src/packages/@knit/needle/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@knit/needle",
   "description": "Knitting needle",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/nice-errors/package.json
+++ b/src/packages/@knit/nice-errors/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@knit/nice-errors",
   "description": "Nice cli errors",
-  "version": "0.8.0"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/path-join/package.json
+++ b/src/packages/@knit/path-join/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@knit/path-join",
-  "version": "0.7.2"
+  "version": "0.0.0-monorepo"
 }

--- a/src/packages/@knit/read-pkg/package.json
+++ b/src/packages/@knit/read-pkg/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@knit/read-pkg",
-  "version": "0.8.2"
+  "version": "0.0.0-monorepo"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4080,7 +4080,7 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-latest-version@^5.0.0:
+latest-version@5.1.0, latest-version@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==


### PR DESCRIPTION
- updates release action to auto inc version
- add a new magic var called KNIT_MODULE_VERSION that is replaced with the latest version from the registry
- sets all versions to 0.0.0-monorepo since the version in code doesn't mater anymore