### PR TITLE
✨optimize pre-release versions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
           git checkout "${GITHUB_HEAD_REF}"
       - run: yarn install
       - name: Set to latest released version
-        run: yarn \#:version
+        run: yarn \#:dist-tag
       - name: Bump prerelease version
         run: yarn \#:prerelease
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '**.js*'
-      - '.github/**'
-      - 'src/packages/**'
 
 env:
   KNIT_WORKING_DIR: src/packages
@@ -96,7 +92,7 @@ jobs:
           always-auth: true
       - run: yarn install
       - name: Set to latest released version
-        run: yarn \#:version
+        run: yarn \#:latest
       - name: Bump release version
         run: yarn \#:release
       - name: Build

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
     "knit:stitch": "yarn knit stitch --parallel",
     "knit:build:cjs": "cross-env NODE_ENV=production babel src/packages -d dist --copy-files --extensions .js,.ts",
     "build": "run-s knit:clean knit:build:cjs knit:stitch",
-    "#:version": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel npm version KNIT_MODULE_VERSION --no-git-tag-version",
+    "#:latest": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel npm version KNIT_MODULE_VERSION_LATEST --no-git-tag-version",
     "#:release": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel --scope modified --range HEAD~.. npm version patch --no-git-tag-version",
-    "#:prerelease": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel --scope modified --range master.. npm version 0.0.0-GIT_SHA --no-git-tag-version --allow-same-version",
+    "#:dist-tag": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel npm version KNIT_MODULE_VERSION_DIST_TAG --no-git-tag-version",
+    "#:prerelease": "babel-node src/packages/@knit/knit/bin/cli.js exec --parallel --scope modified --range HEAD~.. npm version 0.0.0-GIT_SHA --no-git-tag-version --allow-same-version",
     "#:publish": "babel-node src/packages/@knit/knit/bin/cli.js exec --scope unpublished --workspace dist -- npm publish"
   },
   "dependencies": {

--- a/src/packages/@knit/git-commit-sha/index.js
+++ b/src/packages/@knit/git-commit-sha/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+// beep
 import execa from "execa";
 
 type TShortSha = () => Promise<string>;

--- a/src/packages/@knit/knit/tasks/exec.js
+++ b/src/packages/@knit/knit/tasks/exec.js
@@ -5,6 +5,7 @@ import type { TPackageNames } from "@knit/knit-core";
 
 import Listr from "listr";
 import execa from "execa";
+import { gt } from "semver";
 
 import needle from "@knit/needle";
 import pathJoin from "@knit/path-join";
@@ -45,10 +46,22 @@ const tasks = [
                       x = x.replace("KNIT_MODULE_DIR", ctx.modulesMap[m].dir);
                       x = x.replace("ROOT_DIR", needle.paths.rootDir);
 
-                      if (x.includes("KNIT_MODULE_VERSION")) {
+                      const fb = "0.0.0";
+
+                      if (x.includes("KNIT_MODULE_VERSION_DIST_TAG")) {
                         x = x.replace(
-                          "KNIT_MODULE_VERSION",
-                          await latestVersion(m, "0.0.0")
+                          "KNIT_MODULE_VERSION_DIST_TAG",
+                          await latestVersion(m, fb, {
+                            version: normalizeBranch(await currentBranch())
+                          })
+                        );
+                      }
+
+                      if (x.includes("KNIT_MODULE_VERSION_LATEST")) {
+                        const v = await latestVersion(m, fb);
+                        x = x.replace(
+                          "KNIT_MODULE_VERSION_LATEST",
+                          gt(fb, v) ? fb : v
                         );
                       }
 

--- a/src/packages/@knit/latest-version/index.js
+++ b/src/packages/@knit/latest-version/index.js
@@ -8,5 +8,6 @@ type TLatestVersion = (
 ) => Promise<string>;
 export const latestVersion: TLatestVersion = (pkg, fallback, options) =>
   lv(pkg, options)
+    .catch(() => lv(pkg))
     .catch(() => fallback)
     .then(v => v);


### PR DESCRIPTION
when finding pre-releases look for version from the current branch/dist-tag
This way we can just publish a new pre-release for changes per commit and still have the version pointing the lastest pre-releases for that branch
If no pre-release found falls back to latest tag (this would mean the package has not be modified in the PR)
No longer need to check changes from master - just looking at the last commit is fine.

Danger still looks at `master..` because it lists the modified packages based on dist-tag which would point to the latest pre-release