### PR TITLE
🛠run stitch with yarn workspace

### DIFF
--- a/src/packages/@knit/knit-core/index.js
+++ b/src/packages/@knit/knit-core/index.js
@@ -40,11 +40,13 @@ export const getDependencyVersion: TGetDependencyVersion = (
     if (pkg && pkg.version) {
       return pkg.version;
     }
+  } else if (params.pkg.dependencies && params.pkg.dependencies[dep]) {
+    return params.pkg.dependencies[dep];
   }
 
   throw {
     message: `Missing dependency: ${dep}`,
-    stderr: `Could not find ${dep} in the project package.json. Try \`yarn add ${dep}\`.`
+    stderr: `Could not find ${dep} in package.json. Try \`yarn add ${dep}\`.`
   };
 };
 

--- a/src/packages/@knit/knit/bin/cli-stitch.js
+++ b/src/packages/@knit/knit/bin/cli-stitch.js
@@ -8,12 +8,7 @@ const tasks = require("@knit/common-tasks");
 
 module.exports = argv => {
   new Listr(
-    [
-      ...tasks.modules,
-      ...tasks.preflight.knit,
-      ...tasks.readPackages,
-      ...require("../tasks/stitch")
-    ],
+    [...tasks.modules, ...tasks.readPackages, ...require("../tasks/stitch")],
     {
       renderer: log.getRenderer(argv),
       collapse: false


### PR DESCRIPTION
this should be part of the large "work with workspaces" ticket - but this lets stitch be run against projects that use workspaces to update internal package versions.